### PR TITLE
Fix: Image Display Issue in Fastfetch

### DIFF
--- a/config/fastfetch/config.jsonc
+++ b/config/fastfetch/config.jsonc
@@ -11,15 +11,20 @@
 {
     "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
     "logo": {
-    	"source": "~/.config/fastfetch/images/arch.png",
-    	"type": "kitty",
-    	"height": 18,
-    	"padding": {
-    		"top": 2
+//    	"source": "~/.config/fastfetch/images/arch.png",
+//    	"type": "kitty",
+//    	"height": 18,
+//    	"padding": {
+//    		"top": 2
+        "type": "builtin",
+        "color": {
+            "1": "white",
+            "2": "cyan"
     	}
     },
     "display": {
-        "separator": " "
+        "separator": " ",
+        "color": "cyan"
     },
     "modules": [
 	"break",


### PR DESCRIPTION
Fastfetch image rendering is not supported in Alacritty, and it doesn't work with the default Tmux configuration. To address this, I have commented out the image link and replaced it with the default distro logo for compatibility.